### PR TITLE
Fix symbolic links error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linaria-jest",
-  "version": "0.0.4",
+  "version": "0.0.3",
   "description": "Jest utilities for Linaria",
   "author": "Michał Pierzchała <thymikee@gmail.com>",
   "repository": "github:thymikee/linaria-jest",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
   "license": "MIT",
   "scripts": {
     "test": "jest",
-    "lint": "eslint . --cache",
-    "postinstall": "yarn link linaria"
+    "lint": "eslint . --cache"
   },
   "dependencies": {
     "babel-preset-env": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linaria-jest",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Jest utilities for Linaria",
   "author": "Michał Pierzchała <thymikee@gmail.com>",
   "repository": "github:thymikee/linaria-jest",
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "babel-preset-env": "^1.6.0",
-    "linaria": "^0.1.4",
+    "linaria": "^0.5.0",
     "prettier": "^1.7.4"
   },
   "devDependencies": {


### PR DESCRIPTION
- Removes `postinstall` hook, which previously ran `yarn link linaria`
- Updates `linaria` dependency to `^0.5.0`
- Bumps version to `0.0.4`

Fixes #2 